### PR TITLE
add_edit_note_screen 에서 note를 받지 않도록 구현

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,37 @@
+# This is a basic workflow to help you get started with Actions
+
+name: CI
+
+# Controls when the workflow will run
+on:
+  # Triggers the workflow on push or pull request events but only for the "master" branch
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v2
+        with:
+          distribution: 'zulu'
+          java-version: '11'
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: 'stable'
+      - run: flutter pub get
+      - run: flutter test
+#      - run: flutter build apk
+#      - run: flutter build appbundle
+      

--- a/note_app/lib/presentation/add_edit_note/add_edit_note_screen.dart
+++ b/note_app/lib/presentation/add_edit_note/add_edit_note_screen.dart
@@ -8,9 +8,8 @@ import 'package:flutter_note_app/ui/colors.dart';
 import 'package:provider/provider.dart';
 
 class AddEditNoteScreen extends StatefulWidget {
-  final Note? note;
 
-  const AddEditNoteScreen({Key? key, this.note}) : super(key: key);
+  const AddEditNoteScreen({Key? key}) : super(key: key);
 
   @override
   State<AddEditNoteScreen> createState() => _AddEditNoteScreenState();
@@ -32,11 +31,6 @@ class _AddEditNoteScreenState extends State<AddEditNoteScreen> {
   @override
   void initState() {
     super.initState();
-
-    if (widget.note != null) {
-      _titleController.text = widget.note!.title;
-      _contentController.text = widget.note!.content;
-    }
 
     Future.microtask(() {
       final viewModel = context.read<AddEditNoteViewModel>();
@@ -66,12 +60,18 @@ class _AddEditNoteScreenState extends State<AddEditNoteScreen> {
   @override
   Widget build(BuildContext context) {
     final viewModel = context.watch<AddEditNoteViewModel>();
+    final state = viewModel.state;
+
+    if (state.note != null) {
+      _titleController.text = state.note!.title;
+      _contentController.text = state.note!.content;
+    }
 
     return Scaffold(
       floatingActionButton: FloatingActionButton(
         onPressed: () {
           viewModel.onEvent(AddEditNoteEvent.saveNote(
-            widget.note == null ? null : widget.note!.id,
+            state.note == null ? null : state.note!.id,
             _titleController.text,
             _contentController.text,
           ));


### PR DESCRIPTION
viewModel에서 note를 전달받기 때문에 screen에서 note를 전달 받지 않아도 될 것 같습니다. 
그러나 initState에서 controller에 데이터 바인딩 해주는 부분을 build 함수 내로 옮겼다는 것이 단점입니다.(비지니스 로직이 build에 포함됨(initState도 비슷하다고 생각))
initState에서 viewModel을 전달받아 데이터 바인딩을 해줄 수도 있지만 microtask다 보니 기본 text가 잠깐 보이고 바인딩 되는 단점이 있습니다. 
그래서 저는 build 메서드 내에서 처리했습니다.

더 좋은 방법 있으면 의견 주세요!